### PR TITLE
GitHub Actions + Makefile can compile for Windows

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,18 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Install dependencies
+      run: make

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt install gcc-mingw-w64-x86-64 -y
     
     - name: Build Windows executable
-      run: x86_64-w64-minggw32-gcc -o aasm.exe aasm.c
+      run: x86_64-w64-mingw32-gcc -o aasm.exe aasm.c
       
     - name: Test
       run: ./aasm SCR_scripts/test.aa -e

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,5 +14,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - name: Install dependencies
+    - name: Make the program
       run: make
+      
+    - name: Test
+      run: ./aasm SCR_scripts/test.aa -e
+      
+    - name: pwd
+      run: pwd
+      
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./*
+        # The desired behavior if no files are found using the provided path.
+        if-no-files-found: error

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,6 +16,12 @@ jobs:
       
     - name: Make the program
       run: make
+    
+    - name: Install mingw-gcc
+      run: sudo apt install gcc-mingw-w64-x86-64 -y
+    
+    - name: Build Windows executable
+      run: x86_64-w64-minggw32-gcc -o aasm.exe aasm.c
       
     - name: Test
       run: ./aasm SCR_scripts/test.aa -e
@@ -26,6 +32,7 @@ jobs:
         # A file, directory or wildcard pattern that describes what to upload
         path: |
           ./aasm
+          ./aasm.exe
           ./scripts/
         # The desired behavior if no files are found using the provided path.
         if-no-files-found: error

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt install gcc-mingw-w64-x86-64 -y
     
     - name: Build Windows executable
-      run: x86_64-w64-mingw32-gcc -o aasm.exe aasm.c
+      run: make windows
       
     - name: Test
       run: ./aasm SCR_scripts/test.aa -e

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - name: Make the program
+    - name: Build Linux executable
       run: make
+      
+    - name: Test Linux executable
+      run: ./aasm SCR_scripts/test.aa -e
     
     - name: Install mingw-gcc
       run: sudo apt install gcc-mingw-w64-x86-64 -y
     
     - name: Build Windows executable
       run: make windows
-      
-    - name: Test
-      run: ./aasm SCR_scripts/test.aa -e
       
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.3.1

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,13 +20,12 @@ jobs:
     - name: Test
       run: ./aasm SCR_scripts/test.aa -e
       
-    - name: pwd
-      run: pwd
-      
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.3.1
       with:
         # A file, directory or wildcard pattern that describes what to upload
-        path: ./*
+        path: |
+          ./aasm
+          ./scripts/
         # The desired behavior if no files are found using the provided path.
         if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 aasm
+aasm.exe

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@
 CC=gcc
 
 C_FILES = aasm.c
+H_FILES = arbnum.h
 OUTPUT = aasm
 
 MICRO_TARGET=~/.config/micro/syntax/
@@ -11,8 +12,8 @@ MICRO_TARGET=~/.config/micro/syntax/
 RED = \033[0;31m
 NC = \033[0m # No Color
 
-$(OUTPUT): $(C_FILES)
-	$(CC) -o $@ $^ -lm
+$(OUTPUT): $(C_FILES) $(H_FILES)
+	$(CC) -o $@ $(C_FILES) -lm
 
 build: $(OUTPUT)
 

--- a/makefile
+++ b/makefile
@@ -14,6 +14,8 @@ NC = \033[0m # No Color
 $(OUTPUT): $(C_FILES)
 	$(CC) -o $@ $^ -lm
 
+build: $(OUTPUT)
+
 windows:
 	@if x86_64-w64-mingw32-gcc -o $(OUTPUT).exe $(C_FILES); then \
 		echo "Compilation succeeded!"; \
@@ -34,3 +36,11 @@ formicro: $(OUTPUT)
 
 run: $(OUTPUT)
 	./$^
+
+help:
+	@echo "All make commands that you can run:"
+	@echo " make             | Compiles the program for your current platform (Tested on Linux & Windows (Using MSYS2))"
+	@echo " make build       | Does the same"
+	@echo " make forwindows  | Compiles the program for Windows using mingw. (Linux only)"
+	@echo " make formicro    | Compiles and sets up some files to add support for ArbAsm in the Micro editor"
+	@echo " make run         | Compiles and runs the program"

--- a/makefile
+++ b/makefile
@@ -8,10 +8,27 @@ OUTPUT = aasm
 
 MICRO_TARGET=~/.config/micro/syntax/
 
+RED = \033[0;31m
+NC = \033[0m # No Color
+
 $(OUTPUT): $(C_FILES)
 	$(CC) -o $@ $^ -lm
 
-formicro:
+windows:
+	@if x86_64-w64-mingw32-gcc -o $(OUTPUT).exe $(C_FILES); then \
+		echo "Compilation succeeded!"; \
+	else \
+		echo -e "$(RED)Could not use mingw to compile an executable for Windows.$(NC)"; \
+		if apt -v > /dev/null ; then \
+			echo -e "$(RED)Install it by doing:\n # apt install gcc-mingw-w64-x86-64$(NC)"; \
+		else \
+			if pacman -V > /dev/null; then \
+				echo -e "$(RED)Install it by doing:\n # pacman -S mingw-w64-gcc$(NC)"; \
+			fi \
+		fi \
+	fi
+
+formicro: $(OUTPUT)
 	mkdir -p $(MICRO_TARGET)
 	cp scripts/arbasm.yaml $(MICRO_TARGET)
 


### PR DESCRIPTION
### GitHub Actions
Every time you make a commit from now on, GitHub servers will automatically compile ArbAsm into a Linux executable and a Windows executable and upload those (with the scripts directory) as an artifact.
This allows people to download the most recent and newest versions of ArbAsm.

### Makefile can compile for Windows
The makefile now has a new command: `make windows` which uses mingw to compile an executable for Windows platforms.
This command must still be run from Linux! If you want to compile on Windows, you have to install mingw yourself (I have confirmed MSYS2 to work for that)
If mingw is not present on the system, the makefile tries to detect your package manager and gives you the command to install mingw.